### PR TITLE
add support for filters (compression) for smalldata files

### DIFF
--- a/src/mpi_datasource.py
+++ b/src/mpi_datasource.py
@@ -224,7 +224,7 @@ class MPIDataSource(object):
 
 
     def small_data(self, filename=None, keys_to_save=[],
-                   gather_interval=100):
+                   gather_interval=100, filters=None):
         """
         Returns an object that manages small per-event data as
         well as non-event data (e.g. a sum of an image over a run)
@@ -244,6 +244,11 @@ class MPIDataSource(object):
             from all MPI cores every "N" events.  Events are
             counted separately on each core.  If not set,
             only gather results from all cores at end-run.
+
+        filters: tables.Filters,, optional (default None)
+            Filter properties for the smalldata h5 file. Mainly
+            used to configure compression settings.
+            See https://www.pytables.org/usersguide/libref/helper_classes.html#the-filters-class
 
         Example
         -------
@@ -265,7 +270,8 @@ class MPIDataSource(object):
 
         self.global_gather_interval = gather_interval*self.size
         self.sd = SmallData(self, filename=filename, 
-                            keys_to_save=keys_to_save)
+                            keys_to_save=keys_to_save,
+                            filters=filters)
 
         return self.sd
 

--- a/src/smalldata.py
+++ b/src/smalldata.py
@@ -1044,6 +1044,10 @@ class SmallFile(object):
             only the values for 'a' will be saved. Hierarchical data structures
             using dictionaries can be referenced using '/' for each level, e.g.
             event({'c' : {'d' : z}}) --> keys_to_save=['c/d'].
+
+        filters: filters: tables.Filters
+            Filter properties for the smalldata h5 file. Mainly
+            used to configure compression settings.
         """
         self.file_handle = tables.File(filename, 'w', filters=filters)
         self.keys_to_save = keys_to_save

--- a/src/smalldata.py
+++ b/src/smalldata.py
@@ -222,7 +222,7 @@ class SmallData(object):
 
     """
 
-    def __init__(self, datasource_parent, filename=None, keys_to_save=[]):
+    def __init__(self, datasource_parent, filename=None, keys_to_save=[], filters=None):
         """
         Parameters
         ----------
@@ -237,7 +237,11 @@ class SmallData(object):
             add only ['a'] to this list, but call SmallData.event(a=x, b=y),
             only the values for 'a' will be saved. Hierarchical data structures
             using dictionaries can be referenced using '/' for each level, e.g.
-            SmallData.event({'c' : {'d' : z}}) --> keys_to_save=['c/d'].
+            SmallData.event({'c' : {'d' : z}}) --> keys_to_save=['c/d'].i
+
+        filters: tables.Filters
+            Filter properties for the smalldata h5 file. Mainly
+            used to configure compression settings.
         """
 
         self.rank = rank
@@ -255,7 +259,7 @@ class SmallData(object):
             self._newkeys = []
 
         if filename and self.master:
-            self._small_file = SmallFile(filename, keys_to_save)
+            self._small_file = SmallFile(filename, keys_to_save, filters=filters)
             self.add_monitor_function(self._small_file.save_event_data)
 
         return
@@ -1027,7 +1031,7 @@ class SmallFile(object):
     An interface to an HDF5 file for saving data using SmallData and MPIDataSource.
     """
 
-    def __init__(self, filename, keys_to_save=[]):
+    def __init__(self, filename, keys_to_save=[], filters=None):
         """
         Parameters
         ----------
@@ -1041,7 +1045,7 @@ class SmallFile(object):
             using dictionaries can be referenced using '/' for each level, e.g.
             event({'c' : {'d' : z}}) --> keys_to_save=['c/d'].
         """
-        self.file_handle = tables.File(filename, 'w')
+        self.file_handle = tables.File(filename, 'w', filters=filters)
         self.keys_to_save = keys_to_save
         return
 

--- a/src/smalldata.py
+++ b/src/smalldata.py
@@ -1045,7 +1045,7 @@ class SmallFile(object):
             using dictionaries can be referenced using '/' for each level, e.g.
             event({'c' : {'d' : z}}) --> keys_to_save=['c/d'].
 
-        filters: filters: tables.Filters
+        filters: tables.Filters
             Filter properties for the smalldata h5 file. Mainly
             used to configure compression settings.
         """


### PR DESCRIPTION
Add support for compression in smalldata h5 files.
A filters argument can be passed to the smalldata files: https://www.pytables.org/usersguide/libref/helper_classes.html#the-filters-class

Example script to test this:
```
import psana
import sys
import tables


exp = 'xpptut15'
run = 210

ds_name = f'exp={exp}:run={run}:smd'

smd_filters = tables.Filters(complib='lzo', complevel=1)

ds = psana.MPIDataSource(ds_name)

smalldata = ds.small_data('test_comp.h5', gather_interval=10, filters=smd_filters)

det = psana.Detector('opal_1')
ds.break_after(500)

for evt_num, evt in enumerate(ds.events()):
    data = det.calib(evt)
    smalldata.event({'evt_data': data})

smalldata.save()

```